### PR TITLE
Release/0.1.1

### DIFF
--- a/error_handler-lambda.tf
+++ b/error_handler-lambda.tf
@@ -103,7 +103,7 @@ resource "aws_cloudwatch_event_rule" "aws_eventbridge_batch_job_failure" {
     "detail" : {
       "jobName" : [{ "prefix" : "${var.prefix}" }],
       "status" : ["FAILED"]
-      "statusReason" : [{ "anything-but" : ["Terminating job.", "Array Child Job failed", "Dependent Job failed", "Canceled by user via console", "Terminated by user via console"] }]
+      "statusReason" : [{ "anything-but" : ["Terminating job.", "Array Child Job failed", "Dependent Job failed", "Canceled by user via console", "Terminated by user via console", "Terminated via console"] }]
     }
   })
 }

--- a/error_handler.py
+++ b/error_handler.py
@@ -215,7 +215,13 @@ def check_existence(ssm, parameter_name, logger):
         
         try:
             parameter = ssm.get_parameter(Name=parameter_name)["Parameter"]["Value"]
-            logger.info(f"Located {parameter_name} with {parameter} reserved IDL licenses.")
+            if "floating" in parameter_name:
+                ltype = "floating"
+            elif "ql" in parameter_name:
+                ltype = "quicklook dataset"
+            else:
+                ltype = "refined dataset"
+            logger.info(f"Located {ltype} {parameter_name}: {parameter} reserved licenses.")
         except botocore.exceptions.ClientError as e:
             if "(ParameterNotFound)" in str(e) :
                 parameter = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-boto3==1.28.20
-botocore==1.31.20
+boto3==1.28.63
+botocore==1.31.63
 jmespath==1.0.1
 python-dateutil==2.8.2
-s3transfer==0.6.1
+s3transfer==0.7.0
 six==1.16.0
-urllib3==1.26.16
+urllib3==1.26.17

--- a/variables.tf
+++ b/variables.tf
@@ -5,9 +5,9 @@ variable "app_name" {
 }
 
 variable "app_version" {
-  type        = number
+  type        = string
   description = "The application version number"
-  default     = 0.1
+  default     = "0.1.1"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
### Description

Release of Cloud-Generate version 0.1.1.

Scope:

- Update logs for Cloud Metrics.
- Fix SNYK identified vulnerabilities.

### Overview of work done

Delivery Memo: <https://wiki.jpl.nasa.gov/display/PD/Cloud-Generate+v+0.1.1+Delivery+Memo>
ORR: <https://docs.google.com/presentation/d/1khB7ix7kHYdRMRxna61NFmqBAe7cM1zcxLVhw9OjF4M/edit?usp=sharing>

### Overview of verification done

#### Tested in SIT

Test Run Report: <https://cae-testrail.jpl.nasa.gov/testrail/index.php?/runs/view/39705&group_by=cases:title&group_order=asc>

#### Tested in UAT

UAT Test Results: <https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+UAT+Test+v0.1.1+Results>
