### PR TITLE
Feature/podaac 6941 - Update EventBridge rule for P&S failures

### DIFF
--- a/error_handler-lambda.tf
+++ b/error_handler-lambda.tf
@@ -103,7 +103,7 @@ resource "aws_cloudwatch_event_rule" "aws_eventbridge_batch_job_failure" {
     "detail" : {
       "jobName" : [{ "prefix" : "${var.prefix}" }],
       "status" : ["FAILED"]
-      "statusReason" : [{ "anything-but" : ["Terminating job.", "Array Child Job failed", "Dependent Job failed", "Canceled by user via console", "Terminated by user via console", "Terminated via console"] }]
+      "statusReason" : [{ "anything-but" : ["Partition and Submit lambda encountered a failure.", "Terminating job.", "Array Child Job failed", "Dependent Job failed", "Canceled by user via console", "Terminated by user via console", "Terminated via console"] }]
     }
   })
 }


### PR DESCRIPTION
The P&S can fail and it will generate a large number of e-mail notifications for all cancelled jobs and create issues with updating the IDL licenses. This change will ignore the P&S failures preventing the high volume of e-mail notifications and allow P&S to return licenses when it encounters failures.