### PR TITLE
Release/0.1.7

### DIFF
--- a/error_handler-lambda.tf
+++ b/error_handler-lambda.tf
@@ -103,7 +103,7 @@ resource "aws_cloudwatch_event_rule" "aws_eventbridge_batch_job_failure" {
     "detail" : {
       "jobName" : [{ "prefix" : "${var.prefix}" }],
       "status" : ["FAILED"]
-      "statusReason" : [{ "anything-but" : ["Terminating job.", "Array Child Job failed", "Dependent Job failed", "Canceled by user via console", "Terminated by user via console", "Terminated via console"] }]
+      "statusReason" : [{ "anything-but" : ["Partition and Submit lambda encountered a failure.", "Terminating job.", "Array Child Job failed", "Dependent Job failed", "Canceled by user via console", "Terminated by user via console", "Terminated via console"] }]
     }
   })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "app_version" {
   type        = string
   description = "The application version number"
-  default     = "0.1.1"
+  default     = "0.1.3"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
## [0.1.7]

### Description

We are migrating the managed EC2 AWS Batch Compute Environments to Fargate to prevent the need for AMI updates and to hopefully resolve the issue we are seeing with the ECS agent on EC2 instances.

Issues:

- https://github.com/podaac/generate/issues/25
- https://jira.jpl.nasa.gov/browse/PODAAC-6941

Documentation on issue:

- https://wiki.jpl.nasa.gov/pages/viewpage.action?pageId=826914206#GenerateCloudFailures&Recovery-2025-07-05-2025-07-07P&Sfailures


### Overview of work done

- Generate: Adds Fargate compute resources for batch jobs
- Generate: Removes lifeycle 'create_before_destroy' for EC2 compute resources since this policy was preventing terraform from applying the changes
- P&S: Added source hash in terraform file so it can detect changes to the job config json file
- P&S: Set retires to 0 so it only runs once
- Downloader, Combiner, Processor, Uploader, License Returner: Updated job definition/resources for Fargate instead of EC2
- Error Handler: Update EventBridge rule to ignore P&S failures.


### Overview of verification done

- Tested in SIT on three OBPG L2 granules for MODIS Aqua to produce two L2P granules

### Overview of integration done

- Tested in UAT on <TBD> time range
- Analysis of results is located here: <TBD>
- Test Summary: <TBD>